### PR TITLE
Added Lact2 DMI equation (9)

### DIFF
--- a/src/nasem_dairy/NASEM_equations/DMI_equations.py
+++ b/src/nasem_dairy/NASEM_equations/DMI_equations.py
@@ -292,6 +292,20 @@ def calculate_Dt_DMIn_Lact1(Trg_MilkProd, An_BW, An_BCS, An_LactDay,
                        math.exp(-0.053 * An_LactDay))) # Line 390
     return Dt_DMIn_Lact1
 
+# DMIn_eqn == 9 
+def calculate_Dt_DMIn_Lact2(Dt_ForNDF, 
+                            Dt_ADF, 
+                            Dt_NDF, 
+                            Dt_ForDNDF48_ForNDF,
+                            Trg_MilkProd
+) -> float:
+    Dt_DMIn_Lact2 = (12.0 - 0.107 * Dt_ForNDF + 8.17 * Dt_ADF / Dt_NDF + 
+                     0.0253 * Dt_ForDNDF48_ForNDF - 
+                     0.328 * (Dt_ADF / Dt_NDF - 0.602) * 
+                     (Dt_ForDNDF48_ForNDF - 48.3) + 
+                     0.225 * Trg_MilkProd + 0.00390 * 
+                     (Dt_ForDNDF48_ForNDF - 48.3) * (Trg_MilkProd - 33.1))
+    return Dt_DMIn_Lact2
 
 # DMIn_eqn == 10
 def calculate_Dt_DMIn_DryCow1_FarOff(An_BW, Dt_DMIn_BW_LateGest_i):
@@ -333,17 +347,4 @@ def calculate_Dt_DMIn_Calf1(Dt_DMIn_ClfLiq: float,
     return Dt_DMIn_Calf1
 
 
-# Need to implement into execute_model
-def calculate_Dt_DMIn_Lact2(Dt_ForNDF, 
-                            Dt_ADF, 
-                            Dt_NDF, 
-                            Dt_ForDNDF48_ForNDF,
-                            Trg_MilkProd
-) -> float:
-    Dt_DMIn_Lact2 = (12.0 - 0.107 * Dt_ForNDF + 8.17 * Dt_ADF / Dt_NDF + 
-                     0.0253 * Dt_ForDNDF48_ForNDF - 
-                     0.328 * (Dt_ADF / Dt_NDF - 0.602) * 
-                     (Dt_ForDNDF48_ForNDF - 48.3) + 
-                     0.225 * Trg_MilkProd + 0.00390 * 
-                     (Dt_ForDNDF48_ForNDF - 48.3) * (Trg_MilkProd - 33.1))
-    return Dt_DMIn_Lact2
+

--- a/src/nasem_dairy/ration_balancer/ModelOutput.py
+++ b/src/nasem_dairy/ration_balancer/ModelOutput.py
@@ -213,13 +213,17 @@ class ModelOutput:
     def __filter_locals_input(self):
         """
         Remove specified variables from locals_input.
+        Add to dev output for easier development. Not included in search or get_value methods.
         """
+        setattr(self, 'dev_out', {})
         variables_to_remove = [
             'key', 'value', 'num_value', 'feed_library_df', 'feed_data',
             'diet_info_initial', 'diet_data_initial', 'AA_list',
             'An_data_initial', 'mPrt_coeff_list', 'mPrt_k_AA'
         ]
         for key in variables_to_remove:
+            # Add to the dev Category
+            self.dev_out[key] = self.locals_input[key]
             # Remove values that should be excluded from output
             self.locals_input.pop(key, None)
 

--- a/src/nasem_dairy/ration_balancer/ModelOutput.py
+++ b/src/nasem_dairy/ration_balancer/ModelOutput.py
@@ -46,6 +46,7 @@ class ModelOutput:
         self.__sort_Efficiencies()
         self.__sort_Miscellaneous()
         self.__populate_uncategorized()
+        self.dev_out = {}
 
     def _repr_html_(self):
         #This is the HTML display when the ModelOutput object is called directly
@@ -215,7 +216,6 @@ class ModelOutput:
         Remove specified variables from locals_input.
         Add to dev output for easier development. Not included in search or get_value methods.
         """
-        setattr(self, 'dev_out', {})
         variables_to_remove = [
             'key', 'value', 'num_value', 'feed_library_df', 'feed_data',
             'diet_info_initial', 'diet_data_initial', 'AA_list',

--- a/src/nasem_dairy/ration_balancer/execute_model.py
+++ b/src/nasem_dairy/ration_balancer/execute_model.py
@@ -419,13 +419,7 @@ def execute_model(user_diet: pd.DataFrame,
 
     # Calculated again as part of diet_data, value may change depending on 
     # DMIn_eqn selections
-    del(Dt_NDF)
-    del(Dt_ADF)
-    del(Dt_ForNDF)
-    del(Fd_DNDF48)
-    del(Dt_ForDNDF48)
-    del(Dt_ForDNDF48_ForNDF)
-
+    del(Dt_NDF, Dt_ADF, Dt_ForNDF, Fd_DNDF48, Dt_ForDNDF48, Dt_ForDNDF48_ForNDF)
 
     ########################################
     # Step 3: Feed Based Calculations

--- a/src/nasem_dairy/ration_balancer/execute_model.py
+++ b/src/nasem_dairy/ration_balancer/execute_model.py
@@ -98,21 +98,6 @@ def execute_model(user_diet: pd.DataFrame,
         for AA in AA_list
         if AA != "Arg"
     ])
-    # retrieve user's feeds from feed library
-    feed_data = ration_funcs.get_feed_rows_feedlibrary(
-        feeds_to_get=user_diet['Feedstuff'].tolist(),
-        feed_lib_df=feed_library_df)
-
-    # Calculate Fd_DMInp (percentage inclusion as sum of kg_user column)
-    # Then, use the percentages to calculate the DMIn for each ingredient, and 
-    # merge feed data on
-    diet_info_initial = (user_diet.assign(
-        Fd_DMInp=lambda df: df['kg_user'] / df['kg_user'].sum(),
-        Fd_DMIn=lambda df: df['Fd_DMInp'] * animal_input['DMI']).merge(
-            feed_data, how='left', on='Feedstuff'))
-
-    # Add Fd_DNDF48 column, need to add to the database
-    # diet_info_initial['Fd_DNDF48'] = 0
 
     # Calculate additional physiology values
     animal_input['An_PrePartDay'] = (animal_input['An_GestDay'] - 
@@ -166,22 +151,71 @@ def execute_model(user_diet: pd.DataFrame,
     ########################################
     # Step 2: DMI Equations
     ########################################
+    # Prepare diet information
+    ########
+    # retrieve user's feeds from feed library
+    feed_data = ration_funcs.get_feed_rows_feedlibrary(
+        feeds_to_get=user_diet['Feedstuff'].tolist(),
+        feed_lib_df=feed_library_df)
+
+    # Calculate Fd_DMInp (percentage inclusion as sum of kg_user column)
+    # Then, use the percentages to calculate the DMIn for each ingredient, and 
+    # merge feed data on
+    diet_info_initial = (user_diet.assign(
+        Fd_DMInp=lambda df: df['kg_user'] / df['kg_user'].sum(),
+        Fd_DMIn=lambda df: df['Fd_DMInp'] * animal_input['DMI'],
+        )
+        .merge(feed_data, how='left', on='Feedstuff')
+       )
+
+
+    # Add Fd_DNDF48 column, need to add to the database
+    # diet_info_initial['Fd_DNDF48'] = 0
+    
+    
+    ########
     # pre calculations for DMI:
-    ###########################
+    ########
+    diet_info_for_DMI = (diet_info_initial.assign(
+            Fd_For=lambda df: diet.calculate_Fd_For(df['Fd_Conc']),
+            Fd_ForNDF=lambda df: diet.calculate_Fd_ForNDF(
+                df['Fd_NDF'], df['Fd_Conc'])
+        )
+    )
+    # # Need to precalculate Dt_NDF for DMI predicitons, this will be based on 
+    # the user entered DMI (animal_input['DMI])
+    Dt_ADF = (diet_info_for_DMI['Fd_ADF'] * diet_info_for_DMI['Fd_DMInp']).sum()
+    Dt_NDF = (diet_info_for_DMI['Fd_NDF'] * diet_info_for_DMI['Fd_DMInp']).sum()
+    #Dt_For = (diet_info_initial['Fd_For'] * diet_info_initial['Fd_DMInp']).sum()
+
+    # for eqn 9:
+    Dt_ForNDF = (diet_info_for_DMI['Fd_ForNDF'] * diet_info_for_DMI['Fd_DMInp']).sum()
+    Fd_DNDF48 = diet.calculate_Fd_DNDF48(
+        diet_info_for_DMI['Fd_Conc'],
+        diet_info_for_DMI['Fd_DNDF48'])
+    Dt_ForDNDF48 = diet.calculate_Dt_ForDNDF48(
+        diet_info_for_DMI['Fd_DMInp'], 
+        diet_info_for_DMI['Fd_Conc'], 
+        diet_info_for_DMI['Fd_NDF'], 
+        Fd_DNDF48)
+    Dt_ForDNDF48_ForNDF = diet.calculate_Dt_ForDNDF48_ForNDF(Dt_ForDNDF48, Dt_ForNDF)
+
     # Calculate Target milk net energy
     Trg_NEmilk_Milk = milk.calculate_Trg_NEmilk_Milk(
         animal_input['Trg_MilkTPp'], animal_input['Trg_MilkFatp'], 
         animal_input['Trg_MilkLacp']
         )
-    # # Need to precalculate Dt_NDF for DMI predicitons, this will be based on 
-    # the user entered DMI (animal_input['DMI])
-    Dt_NDF = (diet_info_initial['Fd_NDF'] * diet_info_initial['Fd_DMInp']).sum()
+
     # Predict DMI for heifers
     Kb_LateGest_DMIn = DMI.calculate_Kb_LateGest_DMIn(Dt_NDF)
     An_PrePartWklim = DMI.calculate_An_PrePartWklim(
         animal_input['An_PrePartWk']
         )
     An_PrePartWkDurat = An_PrePartWklim * 2
+
+    ####################
+    # Equation selection
+    ####################
 
     if equation_selection['DMIn_eqn'] == 0:
         # print('Using user input DMI')
@@ -195,6 +229,15 @@ def execute_model(user_diet: pd.DataFrame,
             animal_input['An_BCS'], animal_input['An_LactDay'],
             animal_input['An_Parity_rl'], Trg_NEmilk_Milk
             )
+    elif equation_selection['DMIn_eqn'] == 9:
+        animal_input['DMI'] = DMI.calculate_Dt_DMIn_Lact2(
+            Dt_ForNDF, Dt_ADF, Dt_NDF, Dt_ForDNDF48_ForNDF,
+            animal_input['Trg_MilkProd']
+        )
+
+    # elif equation_selection['DMIn_eqn'] == 1:
+
+
     # Individual Heifer DMI Predictions
     elif equation_selection['DMIn_eqn'] in [2, 3, 4, 5, 6, 7]:
         Dt_DMIn_BW_LateGest_i = DMI.calculate_Dt_DMIn_BW_LateGest_i(
@@ -376,7 +419,13 @@ def execute_model(user_diet: pd.DataFrame,
 
     # Calculated again as part of diet_data, value may change depending on 
     # DMIn_eqn selections
-    del (Dt_NDF)
+    del(Dt_NDF)
+    del(Dt_ADF)
+    del(Dt_ForNDF)
+    del(Fd_DNDF48)
+    del(Dt_ForDNDF48)
+    del(Dt_ForDNDF48_ForNDF)
+
 
     ########################################
     # Step 3: Feed Based Calculations

--- a/tests/nutrient_intakes_helpers_test.json
+++ b/tests/nutrient_intakes_helpers_test.json
@@ -225,7 +225,7 @@
                 "Fd_For": [12.1, 13.5, 14.6, 15.2],
                 "Fd_ForNDF": [11.1, 12.2, 13.3, 14.4]
             },
-            "variables": ["ADF", "NDF", "For", "ForNDF"],
+            "variables": ["Fd_ADF", "Fd_NDF", "Fd_For", "Fd_ForNDF"],
             "diet_data": {}
         },
         "Output": {


### PR DESCRIPTION
### Description of changes
Added additional pre-calculations so that the diet based DMI equation for lactation cows (eqn 9) is executed in the model.
Suggest merging for now as lac cows are priority. These pre-calcs may also be better in a function when execute_model is refactored.
Further work required to add calves, but all calf-related equations may need to be isolated better. 
E.g. This equation is actually a DMI prediction.
https://github.com/CNM-University-of-Guelph-dev/NASEM-Model-Python/blob/1224997e4a4442c7148892130c465f8b4e49bea4/src/nasem_dairy/NASEM_equations/nutrient_intakes.py#L1090-L1126

### Issue number/s 
This is a partial fix for Issue #35 but further work is needed for calf equation

### Checklist of all completed
Mark with `[x]` to show completed:  

- [x] No merge conflicts (if conflicts, merge main to branch and resolve before making PR)
- [ ] Tests written (if feature added or refactored)
- [x] pytest passing
- [ ] Docstrings - minor
- [ ] Full documentation